### PR TITLE
Add pricing quote endpoint with confidence scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Pricing Quote Service
+
+This project exposes a `POST /pricing/quote` endpoint for obtaining market and offer prices for Pokémon cards.
+
+## Endpoint
+`POST /pricing/quote`
+
+Request body:
+```json
+{ "psa_cert": "optional", "cardId": "optional", "setId": "optional", "number": "optional", "name": "optional", "includeHistory": true }
+```
+At least one identifier is required.
+
+Response example:
+```json
+{
+  "market_price": 120.0,
+  "offer_price": 96.0,
+  "graded_prices": {"PSA10": 350.0, "PSA9": 180.0},
+  "confidence": 0.72,
+  "explain": {
+    "windowDays": 30,
+    "sampleSize": 27,
+    "variance": 0.18,
+    "sources": ["tcgplayer","ebay"],
+    "trend": "flat",
+    "notes": []
+  }
+}
+```
+If confidence is below `0.6` the service returns `{"no_offer": true, "reason": "low_confidence"}` instead of `offer_price`.
+
+### Confidence policy
+Confidence is a weighted score of sample size, recency, price variance and source diversity. Low sample size, stale or volatile data reduce confidence.
+
+### Trend guard
+The offer price is normally `80%` of market price. If 7‑day median price drops more than 10% vs 30‑day median, the multiplier is reduced by `0.025` per 10% step. Spikes >15% cap the multiplier at `0.78`.
+
+### Caching & Rate limit
+Quotes are cached for 10 minutes by lookup key. Use `forceRefresh=true` to bypass cache. Clients are limited to 30 requests per minute by IP.
+
+## cURL example
+```
+curl -X POST http://localhost:8000/pricing/quote \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Pikachu"}'
+```

--- a/app/adapter.py
+++ b/app/adapter.py
@@ -1,0 +1,28 @@
+from typing import Dict, Optional
+from datetime import datetime, timedelta
+
+
+class PokemonPriceTrackerAdapter:
+    """Mock adapter returning fake data."""
+
+    async def fetch(
+        self,
+        cardId: Optional[str] = None,
+        psa_cert: Optional[str] = None,
+        setId: Optional[str] = None,
+        number: Optional[str] = None,
+        name: Optional[str] = None,
+        includeHistory: bool = True,
+    ) -> Dict:
+        now = datetime.utcnow()
+        history = [
+            {"price": 100 + i, "date": now - timedelta(days=i), "source": "tcgplayer" if i % 2 == 0 else "ebay"}
+            for i in range(1, 31)
+        ]
+        graded = {"PSA10": 350.0, "PSA9": 180.0}
+        return {
+            "market_price": 120.0,
+            "graded_prices": graded,
+            "history": history,
+            "adapterStatus": "ok",
+        }

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,91 @@
+import time
+from typing import Dict
+from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi.responses import JSONResponse
+from uuid import uuid4
+from datetime import datetime, timedelta
+
+from .models import PricingRequest, QuoteResponse, Explain
+from .adapter import PokemonPriceTrackerAdapter
+from .utils import compute_confidence, trend_and_multiplier
+
+app = FastAPI()
+adapter = PokemonPriceTrackerAdapter()
+
+CACHE: Dict[str, Dict] = {}
+RATE_LIMIT: Dict[str, list] = {}
+TTL = 600
+
+metrics = {
+    'quote_requests_total': 0,
+    'quote_cache_hits_total': 0,
+    'quote_errors_total': 0,
+}
+
+
+def rate_limiter(request: Request):
+    ip = request.client.host if request.client else 'anon'
+    now = time.time()
+    window = 60
+    times = RATE_LIMIT.get(ip, [])
+    times = [t for t in times if now - t < window]
+    if len(times) >= 30:
+        raise HTTPException(status_code=429, detail="rate limit")
+    times.append(now)
+    RATE_LIMIT[ip] = times
+
+
+@app.post("/pricing/quote", response_model=QuoteResponse)
+async def quote(req: PricingRequest, request: Request, forceRefresh: bool = False):
+    rate_limiter(request)
+    metrics['quote_requests_total'] += 1
+    lookup = req.cardId or req.psa_cert or (f"{req.setId}-{req.number}" if req.setId and req.number else None) or req.name
+    if not lookup:
+        raise HTTPException(status_code=400, detail="bad input")
+    cache_entry = CACHE.get(lookup)
+    cache_hit = False
+    timing = None
+    if cache_entry and not forceRefresh and time.time() - cache_entry['time'] < TTL:
+        cache_hit = True
+        metrics['quote_cache_hits_total'] += 1
+        data = cache_entry['data']
+    else:
+        start = time.time()
+        data = await adapter.fetch(
+            cardId=req.cardId,
+            psa_cert=req.psa_cert,
+            setId=req.setId,
+            number=req.number,
+            name=req.name,
+            includeHistory=req.includeHistory,
+        )
+        CACHE[lookup] = {'time': time.time(), 'data': data}
+        timing = time.time() - start
+    comps = data.get('history', [])
+    confidence, explain_extra = compute_confidence(comps)
+    prices30 = [c['price'] for c in comps if c['date'] >= datetime.utcnow() - timedelta(days=30)]
+    prices7 = [c['price'] for c in comps if c['date'] >= datetime.utcnow() - timedelta(days=7)]
+    trend, multiplier = trend_and_multiplier(prices7, prices30)
+    explain = Explain(windowDays=30, trend=trend, notes=[], **explain_extra)
+    result = {
+        'market_price': data['market_price'],
+        'graded_prices': data.get('graded_prices', {}),
+        'confidence': confidence,
+        'explain': explain,
+    }
+    if confidence < 0.6:
+        result['no_offer'] = True
+        result['reason'] = 'low_confidence'
+    else:
+        offer = data['market_price'] * multiplier
+        result['offer_price'] = round(offer, 2)
+    log = {
+        'requestId': str(uuid4()),
+        'lookupKey': lookup,
+        'confidence': confidence,
+        'cacheHit': cache_hit,
+        'adapterStatus': data.get('adapterStatus'),
+        'timing': timing,
+    }
+    print(log)
+    return result

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,35 @@
+from typing import Optional, Dict, List
+from pydantic import BaseModel, Field, model_validator
+
+class PricingRequest(BaseModel):
+    psa_cert: Optional[str] = None
+    cardId: Optional[str] = None
+    setId: Optional[str] = None
+    number: Optional[str] = None
+    name: Optional[str] = None
+    includeHistory: bool = True
+
+    @model_validator(mode="after")
+    def at_least_one_identifier(cls, values):
+        if not any(getattr(values, k) for k in ["cardId", "psa_cert", "setId", "name"]):
+            raise ValueError("At least one identifier must be provided")
+        if values.setId and not values.number:
+            raise ValueError("number required with setId")
+        return values
+
+class Explain(BaseModel):
+    windowDays: int
+    sampleSize: int
+    variance: float
+    sources: List[str]
+    trend: str
+    notes: List[str] = []
+
+class QuoteResponse(BaseModel):
+    market_price: float
+    graded_prices: Dict[str, float] = Field(default_factory=dict)
+    confidence: float
+    explain: Explain
+    offer_price: Optional[float] = None
+    no_offer: Optional[bool] = None
+    reason: Optional[str] = None

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+from typing import List, Dict, Tuple
+from statistics import median
+import math
+from datetime import datetime, timedelta
+
+
+def sample_size_score(n: int) -> float:
+    points = [(0, 0.0), (5, 0.4), (20, 0.7), (50, 0.9)]
+    if n <= 0:
+        return 0.0
+    if n >= 50:
+        return 0.9
+    for i in range(len(points) - 1):
+        x1, y1 = points[i]
+        x2, y2 = points[i + 1]
+        if x1 <= n <= x2:
+            ratio = (n - x1) / (x2 - x1)
+            return y1 + ratio * (y2 - y1)
+    return 0.0
+
+
+def recency_score(comps: List[Dict]) -> float:
+    now = datetime.utcnow()
+    seven = now - timedelta(days=7)
+    thirty = now - timedelta(days=30)
+    total30 = sum(1 for c in comps if c['date'] >= thirty)
+    total7 = sum(1 for c in comps if c['date'] >= seven)
+    if total30 == 0:
+        return 0.4
+    pct = total7 / total30
+    if pct >= 0.5:
+        return 1.0
+    return 0.7 if total7 > 0 else 0.4
+
+
+def variance_score(comps: List[Dict]) -> float:
+    prices = [c['price'] for c in comps]
+    if not prices:
+        return 0.0
+    med = median(prices)
+    if med == 0:
+        return 0.0
+    mad = median([abs(p - med) for p in prices])
+    normalized = mad / med
+    return max(0.0, min(1.0, 1 - normalized))
+
+
+def source_diversity_score(comps: List[Dict]) -> float:
+    sources = {c['source'] for c in comps}
+    return 1.0 if len(sources) >= 2 else 0.6
+
+
+def compute_confidence(comps: List[Dict]) -> Tuple[float, Dict]:
+    n = len(comps)
+    sample = sample_size_score(n)
+    recency = recency_score(comps)
+    variance = variance_score(comps)
+    diversity = source_diversity_score(comps)
+    confidence = (
+        0.35 * sample + 0.25 * recency + 0.25 * variance + 0.15 * diversity
+    )
+    explain = {
+        'sampleSize': n,
+        'variance': round(variance_score(comps), 2),
+        'sources': sorted({c['source'] for c in comps})
+    }
+    return round(confidence, 2), explain
+
+
+def trend_and_multiplier(prices7: List[float], prices30: List[float], base_multiplier: float = 0.80) -> Tuple[str, float]:
+    med7 = median(prices7) if prices7 else None
+    med30 = median(prices30) if prices30 else None
+    trend = 'flat'
+    multiplier = base_multiplier
+    if med7 and med30:
+        if med7 < med30 * 0.9:
+            trend = 'down'
+            decline = (med30 - med7) / med30
+            steps = math.floor(decline / 0.10)
+            multiplier -= steps * 0.025
+        elif med7 > med30 * 1.15:
+            trend = 'up'
+            multiplier = min(multiplier, 0.78)
+        else:
+            trend = 'flat'
+    return trend, multiplier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.mark.skipif(os.getenv('PPT_SMOKE_TEST') != '1', reason='smoke test disabled')
+def test_real_adapter():
+    r = client.post('/pricing/quote', json={'name': 'Pikachu'})
+    assert r.status_code == 200

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,49 @@
+import time
+from fastapi.testclient import TestClient
+from app.main import app, CACHE, RATE_LIMIT, metrics
+from app.adapter import PokemonPriceTrackerAdapter
+
+client = TestClient(app)
+
+
+def setup_function():
+    CACHE.clear()
+    RATE_LIMIT.clear()
+    metrics['quote_cache_hits_total'] = 0
+    from app import main
+    main.adapter = PokemonPriceTrackerAdapter()
+
+
+def test_quote_happy_path():
+    resp = client.post("/pricing/quote", json={"name": "pikachu"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "offer_price" in data
+    assert data["confidence"] >= 0
+
+
+def test_low_confidence_no_offer(monkeypatch):
+    async def fake_fetch(self, **kwargs):
+        history = []
+        return {"market_price": 100.0, "graded_prices": {}, "history": history, "adapterStatus": "ok"}
+    monkeypatch.setattr(app.state if hasattr(app, 'state') else app, 'adapter', None, raising=False)
+    from app import main
+    monkeypatch.setattr(main, 'adapter', type('A', (), {'fetch': fake_fetch})())
+    resp = client.post("/pricing/quote", json={"name": "charizard"})
+    assert resp.status_code == 200
+    assert resp.json().get("no_offer") is True
+
+
+def test_rate_limit():
+    for i in range(30):
+        r = client.post("/pricing/quote", json={"name": f"card{i}"})
+        assert r.status_code == 200
+    r = client.post("/pricing/quote", json={"name": "overflow"})
+    assert r.status_code == 429
+
+
+def test_cache_hit_metric():
+    client.post("/pricing/quote", json={"name": "zapdos"})
+    assert metrics['quote_cache_hits_total'] == 0
+    client.post("/pricing/quote", json={"name": "zapdos"})
+    assert metrics['quote_cache_hits_total'] == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+from app.utils import compute_confidence, trend_and_multiplier
+
+
+def make_comp(price, days, source="tcgplayer"):
+    return {"price": price, "date": datetime.utcnow() - timedelta(days=days), "source": source}
+
+
+def test_confidence_scores():
+    comps = [make_comp(100 + i, i, "s1" if i % 2 == 0 else "s2") for i in range(10)]
+    confidence, explain = compute_confidence(comps)
+    assert 0 <= confidence <= 1
+    assert explain['sampleSize'] == 10
+
+
+def test_trend_down_multiplier():
+    prices7 = [100, 90]
+    prices30 = [120, 110, 100]
+    trend, mult = trend_and_multiplier(prices7, prices30)
+    assert trend == 'down'
+    assert mult < 0.80
+
+
+def test_trend_spike_cap():
+    prices7 = [130, 140]
+    prices30 = [100, 110, 105]
+    trend, mult = trend_and_multiplier(prices7, prices30)
+    assert trend == 'up'
+    assert mult == 0.78


### PR DESCRIPTION
## Summary
- implement `/pricing/quote` FastAPI endpoint with in-memory caching and rate limiting
- add confidence and trend utilities to score market data and adjust offers
- document API, caching and rate limiting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689a81e580e483208d836f9528b604f9